### PR TITLE
Producer user

### DIFF
--- a/src/assets/data/registerForm.json
+++ b/src/assets/data/registerForm.json
@@ -7,6 +7,7 @@
     "confirmPassword": "Confirm Password",
     "userType__producer": "Shop/Merchant",
     "userType__reciever": "Applicant",
+    "userType__donor": "Donor",
     "userType__title": "Register as...",
     "submit": "Submit",
     "street": "Street name",

--- a/src/ts/components/pages/RegisterForm/RegisterForm.tsx
+++ b/src/ts/components/pages/RegisterForm/RegisterForm.tsx
@@ -436,6 +436,19 @@ class UnwrappedRegisterForm extends React.PureComponent<RegisterFormProps, Regis
                         />
                         <label htmlFor="Receiver">{registerFormJson.userType__reciever}</label>
                     </div>
+                    <div className="userType D">
+                        <input
+                            type="radio"
+                            className="userTypeButton"
+                            name="userType"
+                            id="Donor"
+                            value="Donor"
+                            aria-checked={this.state.userType === "Donor"}
+                            checked={this.state.userType === "Donor"}
+                            onChange={this.onUserTypeClick}
+                        />
+                        <label htmlFor="Donor">{registerFormJson.userType__donor}</label>
+                    </div>
                 </div>
 
                 <style jsx>{`

--- a/src/ts/config/apis.ts
+++ b/src/ts/config/apis.ts
@@ -1,4 +1,4 @@
-const basePath = "https://api.test.pollopollo.org/api";
+const basePath = "https://api.pollopollo.org/api";
 
 export type Errors = {
     [key: number]: string;

--- a/src/ts/config/apis.ts
+++ b/src/ts/config/apis.ts
@@ -1,4 +1,4 @@
-const basePath = "https://api.pollopollo.org/api";
+const basePath = "https://api.test.pollopollo.org/api";
 
 export type Errors = {
     [key: number]: string;


### PR DESCRIPTION
## Changes:

### Updated the front-end to support `Donors`:

![Screenshot (19)_LI](https://user-images.githubusercontent.com/79650223/109300030-4bc99000-7836-11eb-9297-f4b00ec797cc.jpg)


### Which succesfully gets sent to the backend:

![Screenshot (18)_LI](https://user-images.githubusercontent.com/79650223/109299904-19b82e00-7836-11eb-901c-c74d7476ac68.jpg)

#### Steps to allow backend functionality for this front-end implementation on [Backend donor changes branch](https://github.com/joglr/back-end/tree/donor_changes)

- The [`UsersController`](https://github.com/joglr/back-end/blob/donor_changes/PolloPollo.Web/Controllers/UsersController.cs#L154-L181) recieves the Post request at /api/users. It checks if the received UserRole is of the type `UserRoleEnum`
- [`UserRoleEnum`](https://github.com/joglr/back-end/blob/donor_changes/PolloPollo.Shared/UserRoleEnum.cs) needs to support the type Donor.
